### PR TITLE
add simple create_message server function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1180,6 +1180,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
       "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",

--- a/src/components/chat.rs
+++ b/src/components/chat.rs
@@ -212,7 +212,7 @@ pub fn Chat() -> impl IntoView {
 			set_response.set("".to_string());
 
             let new_message_view = NewMessageView {
-                thread_id: None, // TODO add dynamic thread_id
+                thread_id: Some("1738".to_string()), // TODO add dynamic thread_id
                 content: Some(message_value.clone()),
                 role: role.to_string(),
                 active_model: "gpt-3.5-turbo".to_string(),

--- a/src/components/chat.rs
+++ b/src/components/chat.rs
@@ -194,29 +194,6 @@ pub async fn create_message(new_message_view: NewMessageView) -> Result<(), Serv
     Ok(())
 }
 
-#[server(CreateMessage, "/api")]
-pub async fn create_message() -> Result<(), ServerFnError> {
-    use diesel::prelude::*;
-    use crate::state::AppState;
-    use crate::models::conversations::{Message, NewMessage};
-    use crate::schema::messages::dsl::messages;
-
-    let app_state = use_context::<AppState>()
-        .expect("Failed to get AppState from context");
-
-    let pool = app_state.pool;
-
-    let conn = pool
-        .get()
-        .await
-        .map_err(|e| ServerFnError::ServerError(e.to_string()));
-
-    //  going to need to use the error type cast thing here too will make it 
-    //  it's own module and continue
-
-    todo!();
-}
-
 #[component]
 pub fn Chat() -> impl IntoView {
 	let (message, set_message) = create_signal(String::new());

--- a/src/components/chat.rs
+++ b/src/components/chat.rs
@@ -64,6 +64,9 @@ cfg_if! {
 
 			pub async fn send_message(&self, message: String, tx: mpsc::Sender<Result<Event, anyhow::Error>>) -> Result<(), Error> {
 				info!("Sending message to OpenAI API");
+
+
+
 				let response = self.client.post("https://api.openai.com/v1/chat/completions")
 					.header("Authorization", format!("Bearer {}", self.api_key))
 					.header("Content-Type", "application/json")
@@ -129,6 +132,29 @@ cfg_if! {
 			Err("Function not available in CSR".to_string())
 		}
 	}
+}
+
+#[server(CreateMessage, "/api")]
+pub async fn create_message() -> Result<(), ServerFnError> {
+    use diesel::prelude::*;
+    use crate::state::AppState;
+    use crate::models::conversations::{Message, NewMessage};
+    use crate::schema::messages::dsl::messages;
+
+    let app_state = use_context::<AppState>()
+        .expect("Failed to get AppState from context");
+
+    let pool = app_state.pool;
+
+    let conn = pool
+        .get()
+        .await
+        .map_err(|e| ServerFnError::ServerError(e.to_string()));
+
+    //  going to need to use the error type cast thing here too will make it 
+    //  it's own module and continue
+
+    todo!();
 }
 
 #[component]

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -5,7 +5,7 @@ use leptos_router::A;
 pub fn Navbar() -> impl IntoView {
     view! {
         <div class="flex justify-between items-center ib bg-salmon-500 px-6 py-4 bg-teal-800">
-            <A href="/" class="text-2xl text-salmon-400 hover:text-salmon-600">"thenetworktimes"</A>
+            <A href="/" class="text-2xl text-salmon-400 hover:text-salmon-600">"nwt"</A>
             <A href="/channels" class="text-2xl text-salmon-400 hover:text-salmon-600">"channels"</A>
             <A href="/threadlist" class="text-2xl text-salmon-400 hover:text-salmon-600">"threads"</A>
             <A href="/settings" class="text-2xl text-salmon-400 hover:text-salmon-600">"gear"</A>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,109 +1,114 @@
-#[cfg(feature = "ssr")]
-#[tokio::main]
-async fn main() {
-    use axum::{
-        body::Body as AxumBody,
-        extract::{Query, State},
-        http::Request,
-        response::IntoResponse,
-        routing::get,
-        Router,
-        response::sse::Sse,
-    };
-    use dotenv::dotenv;
-    use env_logger::Env;
-    use leptos::*;
-	use leptos_axum::{generate_route_list, handle_server_fns_with_context, LeptosRoutes};
-    use tokio::sync::mpsc;
-    use std::collections::HashMap;
-	use thenetworktimes::app::*;
-	use thenetworktimes::fileserv::file_and_error_handler;
-	use thenetworktimes::components::chat::{SseStream, send_message_stream};
-    use thenetworktimes::database::db::establish_connection;
-    use thenetworktimes::state::AppState;
-    use thenetworktimes::services::hubble::*;
+use cfg_if::cfg_if;
 
-//    use thenetworktimes::handlers::create_message;
-    // this is a sanity check (simple create_message function) which conflicts 
-    // with the server function of the same name, so i break my no-comments rule
-    // here since it's just so convenient (i should write tests for these things)
+cfg_if! {
+    if #[cfg(feature = "ssr")] {
+        use axum::{
+            body::Body as AxumBody,
+            extract::{Query, State},
+            http::Request,
+            response::IntoResponse,
+            routing::get,
+            Router,
+            response::sse::Sse,
+        };
+        use dotenv::dotenv;
+        use env_logger::Env;
+        use leptos::*;
+        use leptos_axum::{generate_route_list, handle_server_fns_with_context, LeptosRoutes};
+        use tokio::sync::mpsc;
+        use std::collections::HashMap;
+        use thenetworktimes::app::*;
+        use thenetworktimes::fileserv::file_and_error_handler;
+        use thenetworktimes::components::chat::{SseStream, send_message_stream};
+        use thenetworktimes::database::db::establish_connection;
+        use thenetworktimes::state::AppState;
+        use thenetworktimes::services::hubble::*;
 
-    dotenv().ok();
-    env_logger::init_from_env(Env::default().default_filter_or("info"));
-
-    let conf = get_configuration(None).await.unwrap();
-    let leptos_options = conf.leptos_options.clone();
-    let addr = leptos_options.site_addr;
-    let routes = generate_route_list(App);
-
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let pool = establish_connection(&database_url);
-
-    let app_state = AppState {
-        leptos_options: leptos_options.clone(),
-        pool: pool.clone(),
-    };
-
-
-    async fn server_fn_handler(
-        State(app_state): State<AppState>,
-        request: Request<AxumBody>,
-    ) -> impl IntoResponse {
-        handle_server_fns_with_context(
-            move || {
-                provide_context(app_state.clone());
-            },
-            request,
-        )
-        .await
-    }
-
-    let app = Router::new()
-        .route(
-            "/api/*fn_name",
-            get(server_fn_handler).post(server_fn_handler),
-        )
- //        .route("/api/create_message", post(create_message))
-        .route("/api/userNameProofsByFid/:fid", get(get_username_proofs_by_fid))
-        .route("/api/userDataByFid", get(get_user_data_by_fid))
-        .route("/api/castById/:fid/:hash", get(get_cast_by_id))
-        .route("/api/castsByFid/:fid", get(get_casts_by_fid))
-        .route("/api/channels", get(get_channels))
-        .route("/api/castsByChannel/:channel", get(get_casts_by_parent))
-        .route("/api/castsByMention/:fid", get(get_casts_by_mention))
-        .route("/api/reactionsByCast", get(get_reactions_by_cast))
-        .leptos_routes_with_handler(routes, get(|State(app_state): State<AppState>, request: Request<AxumBody>| async move {
-            let handler = leptos_axum::render_app_async_with_context(
-                app_state.leptos_options.clone(),
-                move || {
-                    provide_context(app_state.clone());
-                },
-                move || view! { <App/> },
-            );
-
-            handler(request).await.into_response()
-        }))
-        .route("/api/send_message_stream", axum::routing::get(|Query(params): Query<HashMap<String, String>>| async move {
-            let (tx, rx) = mpsc::channel(100);
-            if let Some(message) = params.get("message") {
-                let message = message.clone();
-                tokio::spawn(async move {
-                    send_message_stream(message, tx).await;
-                });
+        #[tokio::main]
+        async fn main() {
+        
+        //    use thenetworktimes::handlers::create_message;
+            // this is a sanity check (simple create_message function) which conflicts 
+            // with the server function of the same name, so i break my no-comments rule
+            // here since it's just so convenient (i should write tests for these things)
+        
+            dotenv().ok();
+            env_logger::init_from_env(Env::default().default_filter_or("info"));
+        
+            let conf = get_configuration(None).await.unwrap();
+            let leptos_options = conf.leptos_options.clone();
+            let addr = leptos_options.site_addr;
+            let routes = generate_route_list(App);
+        
+            let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+            let pool = establish_connection(&database_url);
+        
+            let app_state = AppState {
+                leptos_options: leptos_options.clone(),
+                pool: pool.clone(),
+            };
+        
+        
+            async fn server_fn_handler(
+                State(app_state): State<AppState>,
+                request: Request<AxumBody>,
+            ) -> impl IntoResponse {
+                handle_server_fns_with_context(
+                    move || {
+                        provide_context(app_state.clone());
+                    },
+                    request,
+                )
+                .await
             }
-            Sse::new(SseStream { receiver: rx })
-        }))
-        .fallback(file_and_error_handler)
-        .with_state(app_state);
-
-    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    logging::log!("listening on http://{}", &addr);
-    axum::serve(listener, app.into_make_service()).await.unwrap();
-}
-
-#[cfg(not(feature = "ssr"))]
-pub fn main() {
-    // no client-side main function
-    // unless we want this to work with e.g., Trunk for a purely client-side app
-    // see lib.rs for hydration function instead
+        
+            let app = Router::new()
+                .route(
+                    "/api/*fn_name",
+                    get(server_fn_handler).post(server_fn_handler),
+                )
+         //        .route("/api/create_message", post(create_message))
+                .route("/api/userNameProofsByFid/:fid", get(get_username_proofs_by_fid))
+                .route("/api/userDataByFid", get(get_user_data_by_fid))
+                .route("/api/castById/:fid/:hash", get(get_cast_by_id))
+                .route("/api/castsByFid/:fid", get(get_casts_by_fid))
+                .route("/api/channels", get(get_channels))
+                .route("/api/castsByChannel/:channel", get(get_casts_by_parent))
+                .route("/api/castsByMention/:fid", get(get_casts_by_mention))
+                .route("/api/reactionsByCast", get(get_reactions_by_cast))
+                .leptos_routes_with_handler(routes, get(|State(app_state): State<AppState>, request: Request<AxumBody>| async move {
+                    let handler = leptos_axum::render_app_async_with_context(
+                        app_state.leptos_options.clone(),
+                        move || {
+                            provide_context(app_state.clone());
+                        },
+                        move || view! { <App/> },
+                    );
+        
+                    handler(request).await.into_response()
+                }))
+                .route("/api/send_message_stream", axum::routing::get(|Query(params): Query<HashMap<String, String>>| async move {
+                    let (tx, rx) = mpsc::channel(100);
+                    if let Some(message) = params.get("message") {
+                        let message = message.clone();
+                        tokio::spawn(async move {
+                            send_message_stream(message, tx).await;
+                        });
+                    }
+                    Sse::new(SseStream { receiver: rx })
+                }))
+                .fallback(file_and_error_handler)
+                .with_state(app_state);
+        
+            let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+            logging::log!("listening on http://{}", &addr);
+            axum::serve(listener, app.into_make_service()).await.unwrap();
+        }
+    } else {
+        pub fn main() {
+            // no client-side main function
+            // unless we want this to work with e.g., Trunk for a purely client-side app
+            // see lib.rs for hydration function instead
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,13 @@ async fn main() {
 	use thenetworktimes::fileserv::file_and_error_handler;
 	use thenetworktimes::components::chat::{SseStream, send_message_stream};
     use thenetworktimes::database::db::establish_connection;
-//    use thenetworktimes::handlers::create_message;
     use thenetworktimes::state::AppState;
     use thenetworktimes::services::hubble::*;
+
+//    use thenetworktimes::handlers::create_message;
+    // this is a sanity check (simple create_message function) which conflicts 
+    // with the server function of the same name, so i break my no-comments rule
+    // here since it's just so convenient (i should write tests for these things)
 
     dotenv().ok();
     env_logger::init_from_env(Env::default().default_filter_or("info"));
@@ -59,7 +63,7 @@ async fn main() {
             "/api/*fn_name",
             get(server_fn_handler).post(server_fn_handler),
         )
- //       .route("/api/create_message", post(create_message))
+ //        .route("/api/create_message", post(create_message))
         .route("/api/userNameProofsByFid/:fid", get(get_username_proofs_by_fid))
         .route("/api/userDataByFid", get(get_user_data_by_fid))
         .route("/api/castById/:fid/:hash", get(get_cast_by_id))

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ async fn main() {
         extract::{Query, State},
         http::Request,
         response::IntoResponse,
-        routing::{get, post},
+        routing::get,
         Router,
         response::sse::Sse,
     };
@@ -20,7 +20,7 @@ async fn main() {
 	use thenetworktimes::fileserv::file_and_error_handler;
 	use thenetworktimes::components::chat::{SseStream, send_message_stream};
     use thenetworktimes::database::db::establish_connection;
-    use thenetworktimes::handlers::create_message;
+//    use thenetworktimes::handlers::create_message;
     use thenetworktimes::state::AppState;
     use thenetworktimes::services::hubble::*;
 
@@ -59,7 +59,7 @@ async fn main() {
             "/api/*fn_name",
             get(server_fn_handler).post(server_fn_handler),
         )
-        .route("/api/create_message", post(create_message))
+ //       .route("/api/create_message", post(create_message))
         .route("/api/userNameProofsByFid/:fid", get(get_username_proofs_by_fid))
         .route("/api/userDataByFid", get(get_user_data_by_fid))
         .route("/api/castById/:fid/:hash", get(get_cast_by_id))

--- a/src/models/conversations.rs
+++ b/src/models/conversations.rs
@@ -87,7 +87,7 @@ cfg_if! { if #[cfg(feature = "ssr")] {
     }
 
     // message data from the client ("new type" or "insert type" pattern)
-    #[derive(Insertable, Deserialize)]
+    #[derive(Debug, Insertable, Deserialize)]
     #[diesel(table_name = messages)]
     pub struct NewMessage {
         pub thread_id: Option<String>,

--- a/src/tmp.txt
+++ b/src/tmp.txt
@@ -1,3 +1,15 @@
 helpful logging command run command
 
 cargo leptos watch > output.log 2>&1
+
+
+
+curl -X POST http://localhost:3000/api/create_message \
+     -H "Content-Type: application/json" \
+     -d '{
+           "thread_id": "1729",
+           "content": "ooo im curlinggg",
+           "role": "user",
+           "active_model": "gpt-3.5-turbo",
+           "active_lab": "openai"
+         }'


### PR DESCRIPTION
this PR contains 2 new server functions related to chat message storage in
the postgres db. i want to get better at using server functions in leptos since
they are isomorphic, server and client can call them in the same way. so, i 
have some very simple related functions which are not communicating with 
eachother in any way yet.

- the create_message server function simply stores the user input message
- the get_threads server functions just fetches the thread id and created_at

obvi much to do, but i like this server function pattern